### PR TITLE
Add JIRA MCP Server Response Format Improvement

### DIFF
--- a/docs/design_docs/jira-mcp-server_02.md
+++ b/docs/design_docs/jira-mcp-server_02.md
@@ -1,0 +1,269 @@
+# Design Document: JIRA MCP Server Response Format Improvement
+
+## Overview
+
+JIRA MCP サーバーのレスポンス形式を改善し、より使いやすい形式に整形する実装を行います。
+
+### Goals
+
+- JIRA API レスポンスの構造を維持しつつ、必要なフィールドのみを含める
+- Description フィールドを ADF から Markdown 形式に変換
+- 一貫性のあるレスポンス形式の提供
+
+### Non-Goals
+
+- JIRA API の機能拡張
+- 新しいエンドポイントの追加
+- パフォーマンスの最適化
+
+## Technical Design
+
+### System Architecture
+
+現在の構成を維持しつつ、レスポンス形式の変換処理を追加します。
+
+```mermaid
+sequenceDiagram
+    Client->>JIRA MCP Server: Request
+    JIRA MCP Server->>JIRA API: API Request
+    JIRA API->>JIRA MCP Server: Response (ADF format)
+    Note over JIRA MCP Server: Transform Response
+    Note over JIRA MCP Server: Convert ADF to Markdown
+    JIRA MCP Server->>Client: Formatted Response
+```
+
+### Data Structures
+
+#### 1. Response Interface
+
+```typescript
+interface JiraMcpResponse {
+  content: Array<{
+    type: "text";
+    text: string; // Stringified JSON
+  }>;
+}
+
+interface JiraApiResponse {
+  expand: string;
+  startAt: number;
+  maxResults: number;
+  total: number;
+  issues: JiraIssue[];
+}
+
+interface JiraIssue {
+  expand: string;
+  id: string;
+  self: string;
+  key: string;
+  fields: {
+    labels: string[];
+    assignee: JiraUser | null;
+    reporter: JiraUser;
+    progress: {
+      progress: number;
+      total: number;
+    };
+    issuetype: {
+      id: string;
+      name: string;
+    };
+    project: {
+      id: string;
+      key: string;
+      name: string;
+    };
+    updated: string;
+    customfield_10015: string; // start date
+    duedate: string;
+    summary: string;
+    description: string; // Converted to Markdown
+    status: {
+      name: string;
+      id: string;
+    };
+    creator: JiraUser;
+    created: string;
+    fixVersions: Array<{
+      id: string;
+      name: string;
+      archived: boolean;
+      released: boolean;
+      releaseDate: string;
+    }>;
+  };
+}
+```
+
+### Core Components
+
+#### 1. ADF to Markdown Converter
+
+```typescript
+class ADFConverter {
+  private static processNode(node: ADFNode): string;
+  private static processContent(content: ADFNode[]): string;
+  private static convertTable(node: ADFTableNode): string;
+  private static convertText(node: ADFTextNode): string;
+
+  public static convert(doc: ADFDocument): string;
+}
+```
+
+#### 2. Response Formatter
+
+```typescript
+class ResponseFormatter {
+  private static formatIssue(issue: JiraIssue): FormattedIssue;
+  private static formatFields(fields: JiraIssueFields): FormattedFields;
+
+  public static format(response: JiraApiResponse): JiraMcpResponse;
+}
+```
+
+### Implementation Details
+
+#### 1. ADF to Markdown 変換ルール
+
+| ADF Element | Markdown Format      |
+| ----------- | -------------------- |
+| heading     | `#` × level + text   |
+| paragraph   | text + `\n\n`        |
+| text        | plain text           |
+| strong      | `**text**`           |
+| em          | `*text*`             |
+| table       | `\|` separated cells |
+| list        | `- ` or `1. `        |
+
+#### 2. エラーハンドリング
+
+```typescript
+try {
+  const response = await client.searchIssues(params);
+  const formattedResponse = ResponseFormatter.format(response);
+  return {
+    content: [
+      {
+        type: "text",
+        text: JSON.stringify(formattedResponse, null, 2),
+      },
+    ],
+  };
+} catch (error) {
+  return {
+    isError: true,
+    content: [
+      {
+        type: "text",
+        text: error instanceof Error ? error.message : "Unknown error occurred",
+      },
+    ],
+  };
+}
+```
+
+## Implementation Tasks
+
+### Phase 1: 基本設定と型定義
+
+1. プロジェクト構造の整理
+
+   - [ ] src/jira/types/ ディレクトリの作成
+   - [ ] src/jira/utils/ ディレクトリの作成
+   - [ ] src/jira/formatters/ ディレクトリの作成
+
+2. 型定義の実装
+   - [ ] types/jira-response.ts の作成
+     - JiraMcpResponse インターフェース
+     - JiraApiResponse インターフェース
+   - [ ] types/jira-issue.ts の作成
+     - JiraIssue インターフェース
+     - JiraUser インターフェース
+   - [ ] types/adf.ts の作成
+     - ADFDocument 型
+     - ADFNode 型
+     - その他 ADF 関連の型定義
+
+### Phase 2: ADF to Markdown コンバーター実装
+
+1. 基本構造の実装
+
+   - [ ] utils/adf-converter.ts の作成
+   - [ ] ADFConverter クラスの基本構造実装
+   - [ ] processNode メソッドのスケルトン実装
+
+2. 基本要素の変換実装
+
+   - [ ] テキスト変換の実装
+   - [ ] 段落変換の実装
+   - [ ] 見出し変換の実装
+   - [ ] 強調（bold, italic）変換の実装
+
+3. 複雑な要素の変換実装
+
+   - [ ] テーブル変換の実装
+   - [ ] リスト変換の実装
+   - [ ] リンク変換の実装
+   - [ ] コード変換の実装
+
+4. エッジケース対応
+   - [ ] null/undefined チェックの実装
+   - [ ] ネストされた要素の処理実装
+   - [ ] 未知の要素タイプのフォールバック実装
+
+### Phase 3: レスポンスフォーマッター実装
+
+1. 基本構造の実装
+
+   - [ ] formatters/response-formatter.ts の作成
+   - [ ] ResponseFormatter クラスの基本構造実装
+
+2. フォーマッターメソッドの実装
+
+   - [ ] formatIssue メソッドの実装
+   - [ ] formatFields メソッドの実装
+   - [ ] format メソッドの実装
+
+3. エラーハンドリングの実装
+   - [ ] try-catch ブロックの実装
+   - [ ] エラーメッセージのフォーマット実装
+   - [ ] エラーレスポンスの型定義
+
+### Phase 4: MCP Server 統合
+
+1. サーバー更新
+
+   - [ ] index.ts の更新
+   - [ ] 新しいフォーマッターの統合
+   - [ ] エラーハンドリングの統合
+
+2. search_issues ツールの更新
+
+   - [ ] レスポンスフォーマッターの統合
+   - [ ] エラーハンドリングの統合
+   - [ ] パラメータバリデーションの更新
+
+3. get_issue ツールの更新
+   - [ ] レスポンスフォーマッターの統合
+   - [ ] エラーハンドリングの統合
+   - [ ] パラメータバリデーションの更新
+
+### Phase 5: 最終調整とドキュメント
+
+1. コードクリーンアップ
+
+   - [ ] 未使用コードの削除
+   - [ ] コードスタイルの統一
+   - [ ] コメントの追加と更新
+
+2. ドキュメント更新
+
+   - [ ] README.md の更新
+   - [ ] API ドキュメントの更新
+   - [ ] 変換ルールドキュメントの作成
+
+3. 最終確認
+   - [ ] 全ての機能の動作確認
+   - [ ] エラーケースの確認
+   - [ ] パフォーマンスの確認

--- a/src/jira/config.ts
+++ b/src/jira/config.ts
@@ -33,3 +33,18 @@ export function loadConfig(): Config {
 
 // Default configuration
 export const config = loadConfig();
+
+/**
+ * JIRA configuration
+ */
+export interface JiraConfig {
+  baseUrl: string;
+  email: string;
+  apiToken: string;
+}
+
+export const jiraConfig: JiraConfig = {
+  baseUrl: process.env.JIRA_BASE_URL || "",
+  email: process.env.JIRA_EMAIL || "",
+  apiToken: process.env.JIRA_API_TOKEN || "",
+};

--- a/src/jira/formatters/response-formatter.ts
+++ b/src/jira/formatters/response-formatter.ts
@@ -1,0 +1,80 @@
+import type { JiraIssue } from "../types/jira-issue.js";
+import type {
+  JiraApiResponse,
+  JiraMcpResponse,
+} from "../types/jira-response.js";
+import { ADFConverter } from "../utils/adf-converter.js";
+
+/**
+ * Formats JIRA API response into MCP response format
+ */
+export class ResponseFormatter {
+  /**
+   * Format JIRA API response
+   */
+  public static format(response: JiraApiResponse): JiraMcpResponse {
+    const formattedIssues = response.issues.map((issue) =>
+      this.formatIssue(issue)
+    );
+
+    return {
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify(
+            {
+              ...response,
+              issues: formattedIssues,
+            },
+            null,
+            2
+          ),
+        },
+      ],
+    };
+  }
+
+  /**
+   * Format a single JIRA issue
+   */
+  private static formatIssue(issue: JiraIssue): any {
+    const { fields, ...rest } = issue;
+    return {
+      ...rest,
+      fields: this.formatFields(fields),
+    };
+  }
+
+  /**
+   * Format issue fields
+   */
+  private static formatFields(fields: JiraIssue["fields"]): any {
+    const { description, ...rest } = fields;
+
+    // Convert description from ADF to Markdown if it exists and is an object
+    const formattedDescription =
+      typeof description === "object" && description !== null
+        ? ADFConverter.convert(description as any)
+        : description;
+
+    return {
+      ...rest,
+      description: formattedDescription,
+    };
+  }
+
+  /**
+   * Format error response
+   */
+  public static formatError(error: Error): JiraMcpResponse {
+    return {
+      isError: true,
+      content: [
+        {
+          type: "text",
+          text: error.message,
+        },
+      ],
+    };
+  }
+}

--- a/src/jira/types/adf.ts
+++ b/src/jira/types/adf.ts
@@ -1,0 +1,74 @@
+/**
+ * Atlassian Document Format (ADF) type definitions
+ */
+
+export type ADFNodeType =
+  | "doc"
+  | "paragraph"
+  | "text"
+  | "heading"
+  | "bulletList"
+  | "orderedList"
+  | "listItem"
+  | "table"
+  | "tableRow"
+  | "tableCell"
+  | "blockquote"
+  | "rule"
+  | "hardBreak"
+  | "mention"
+  | "emoji"
+  | "inlineCard"
+  | "mediaGroup"
+  | "mediaSingle"
+  | "media";
+
+export interface ADFMark {
+  type: "strong" | "em" | "strike" | "code" | "underline" | "link";
+  attrs?: {
+    href?: string;
+    title?: string;
+  };
+}
+
+export interface ADFNode {
+  type: ADFNodeType;
+  content?: ADFNode[];
+  marks?: ADFMark[];
+  attrs?: {
+    level?: number;
+    text?: string;
+    url?: string;
+    id?: string;
+    [key: string]: any;
+  };
+  text?: string;
+  parent?: ADFNode;
+}
+
+export interface ADFDocument {
+  version: number;
+  type: "doc";
+  content: ADFNode[];
+}
+
+export interface ADFTableNode extends ADFNode {
+  type: "table";
+  content: ADFTableRowNode[];
+}
+
+export interface ADFTableRowNode extends ADFNode {
+  type: "tableRow";
+  content: ADFTableCellNode[];
+}
+
+export interface ADFTableCellNode extends ADFNode {
+  type: "tableCell";
+  content: ADFNode[];
+}
+
+export interface ADFTextNode extends ADFNode {
+  type: "text";
+  text: string;
+  marks?: ADFMark[];
+}

--- a/src/jira/types/jira-issue.ts
+++ b/src/jira/types/jira-issue.ts
@@ -1,0 +1,57 @@
+/**
+ * JIRA User interface
+ */
+export interface JiraUser {
+  accountId: string;
+  emailAddress?: string;
+  displayName: string;
+  active: boolean;
+  timeZone?: string;
+  accountType: string;
+}
+
+/**
+ * JIRA Issue interface
+ */
+export interface JiraIssue {
+  expand: string;
+  id: string;
+  self: string;
+  key: string;
+  fields: {
+    labels: string[];
+    assignee: JiraUser | null;
+    reporter: JiraUser;
+    progress: {
+      progress: number;
+      total: number;
+    };
+    issuetype: {
+      id: string;
+      name: string;
+    };
+    project: {
+      id: string;
+      key: string;
+      name: string;
+    };
+    updated: string;
+    customfield_10015: string; // start date
+    duedate: string;
+    summary: string;
+    description: string; // Converted to Markdown
+    status: {
+      name: string;
+      id: string;
+    };
+    creator: JiraUser;
+    created: string;
+    fixVersions: Array<{
+      id: string;
+      name: string;
+      archived: boolean;
+      released: boolean;
+      releaseDate: string;
+    }>;
+  };
+}

--- a/src/jira/types/jira-response.ts
+++ b/src/jira/types/jira-response.ts
@@ -1,0 +1,25 @@
+/**
+ * JIRA MCP Server response interface
+ */
+export interface JiraMcpResponse {
+  [key: string]: unknown;
+  content: Array<{
+    type: "text";
+    text: string; // Stringified JSON
+  }>;
+  isError?: boolean;
+}
+
+/**
+ * JIRA API response interface
+ */
+export interface JiraApiResponse {
+  expand: string;
+  startAt: number;
+  maxResults: number;
+  total: number;
+  issues: JiraIssue[];
+}
+
+// Import this from jira-issue.ts once created
+import type { JiraIssue } from "./jira-issue.js";

--- a/src/jira/utils/adf-converter.ts
+++ b/src/jira/utils/adf-converter.ts
@@ -1,0 +1,174 @@
+import type {
+  ADFDocument,
+  ADFMark,
+  ADFNode,
+  ADFTableNode,
+  ADFTextNode,
+} from "../types/adf.js";
+
+/**
+ * Converts Atlassian Document Format (ADF) to Markdown
+ */
+export class ADFConverter {
+  /**
+   * Convert an ADF document to Markdown
+   */
+  public static convert(doc: ADFDocument): string {
+    if (!doc.content) return "";
+    return this.processContent(doc.content);
+  }
+
+  /**
+   * Process an array of ADF nodes
+   */
+  private static processContent(content: ADFNode[]): string {
+    return content.map((node) => this.processNode(node)).join("");
+  }
+
+  /**
+   * Process a single ADF node
+   */
+  private static processNode(node: ADFNode): string {
+    switch (node.type) {
+      case "text":
+        return this.convertText(node as ADFTextNode);
+      case "paragraph":
+        return this.convertParagraph(node);
+      case "heading":
+        return this.convertHeading(node);
+      case "bulletList":
+        return this.convertBulletList(node);
+      case "orderedList":
+        return this.convertOrderedList(node);
+      case "listItem":
+        return this.convertListItem(node);
+      case "table":
+        return this.convertTable(node as ADFTableNode);
+      case "blockquote":
+        return this.convertBlockquote(node);
+      case "rule":
+        return "---\n";
+      case "hardBreak":
+        return "\n";
+      default:
+        return node.text || "";
+    }
+  }
+
+  /**
+   * Convert text node with marks
+   */
+  private static convertText(node: ADFTextNode): string {
+    if (!node.text) return "";
+
+    let text = node.text;
+    if (!node.marks || node.marks.length === 0) return text;
+
+    // Apply marks in reverse order to handle nested marks correctly
+    return node.marks.reduceRight((text, mark) => {
+      return this.applyMark(text, mark);
+    }, text);
+  }
+
+  /**
+   * Apply mark to text
+   */
+  private static applyMark(text: string, mark: ADFMark): string {
+    switch (mark.type) {
+      case "strong":
+        return `**${text}**`;
+      case "em":
+        return `*${text}*`;
+      case "strike":
+        return `~~${text}~~`;
+      case "code":
+        return `\`${text}\``;
+      case "link":
+        return mark.attrs?.href ? `[${text}](${mark.attrs.href})` : text;
+      default:
+        return text;
+    }
+  }
+
+  /**
+   * Convert paragraph node
+   */
+  private static convertParagraph(node: ADFNode): string {
+    if (!node.content) return "\n\n";
+    return `${this.processContent(node.content)}\n\n`;
+  }
+
+  /**
+   * Convert heading node
+   */
+  private static convertHeading(node: ADFNode): string {
+    if (!node.content) return "";
+    const level = node.attrs?.level || 1;
+    const hashes = "#".repeat(level);
+    return `${hashes} ${this.processContent(node.content)}\n\n`;
+  }
+
+  /**
+   * Convert bullet list node
+   */
+  private static convertBulletList(node: ADFNode): string {
+    if (!node.content) return "";
+    return this.processContent(node.content);
+  }
+
+  /**
+   * Convert ordered list node
+   */
+  private static convertOrderedList(node: ADFNode): string {
+    if (!node.content) return "";
+    return this.processContent(node.content);
+  }
+
+  /**
+   * Convert list item node
+   */
+  private static convertListItem(node: ADFNode): string {
+    if (!node.content) return "";
+    const parent = node.parent as ADFNode;
+    const prefix = parent?.type === "orderedList" ? "1. " : "- ";
+    return `${prefix}${this.processContent(node.content)}\n`;
+  }
+
+  /**
+   * Convert table node
+   */
+  private static convertTable(node: ADFTableNode): string {
+    if (!node.content) return "";
+
+    const rows = node.content.map((row) => {
+      if (!row.content) return "";
+      return `| ${row.content
+        .map((cell) => {
+          if (!cell.content) return "";
+          return this.processContent(cell.content).trim();
+        })
+        .join(" | ")} |`;
+    });
+
+    // Add header separator after first row
+    if (rows.length > 0) {
+      const columnCount = rows[0].split("|").length - 2; // -2 for leading/trailing |
+      const separator = `|${" --- |".repeat(columnCount)}`;
+      rows.splice(1, 0, separator);
+    }
+
+    return `${rows.join("\n")}\n\n`;
+  }
+
+  /**
+   * Convert blockquote node
+   */
+  private static convertBlockquote(node: ADFNode): string {
+    if (!node.content) return "";
+    const content = this.processContent(node.content)
+      .split("\n")
+      .map((line) => `> ${line}`)
+      .join("\n");
+    return `${content}\n\n`;
+  }
+}


### PR DESCRIPTION
- Introduced a design document detailing the improvements to the JIRA MCP Server response format.
- Goals include maintaining the JIRA API response structure while including only necessary fields, converting the Description field from ADF to Markdown, and providing a consistent response format.
- Document outlines technical design, system architecture, core components, implementation tasks, and error handling strategies.
- Added type definitions for ADF and JIRA responses to enhance clarity and maintainability.
- Established a structured approach for converting ADF to Markdown and formatting JIRA API responses.

<!-- GitHub Copilot コードレビューへの指示: このプルリクエストをレビューしてコメントする場合は必ず日本語で行ってください。 -->
