### PR TITLE
Add getIssueComments functionality to JiraClient and server

### DIFF
--- a/src/jira/README.md
+++ b/src/jira/README.md
@@ -6,6 +6,7 @@ A Model Context Protocol (MCP) server for interacting with JIRA Cloud. This serv
 
 - Search JIRA issues using JQL queries
 - Retrieve detailed information about specific JIRA issues
+- Retrieve comments for specific JIRA issues
 - Configurable field selection for both search and get operations
 
 ## Installation
@@ -85,6 +86,28 @@ Example:
 {
   "issueKey": "PROJECT-123",
   "fields": ["summary", "description", "status", "assignee"]
+}
+```
+
+#### get_issue_comments
+
+Retrieve comments for a specific JIRA issue.
+
+Parameters:
+
+- `issueIdOrKey` (string, required): JIRA issue key (e.g., 'PROJECT-123')
+- `startAt` (number, optional): Starting index for pagination
+- `maxResults` (number, optional): Maximum number of comments to return
+- `orderBy` (string, optional): Order of comments (e.g., 'created', '-created')
+- `expand` (string, optional): Additional information to include
+
+Example:
+
+```json
+{
+  "issueIdOrKey": "PROJECT-123",
+  "maxResults": 20,
+  "orderBy": "-created"
 }
 ```
 

--- a/src/jira/client.ts
+++ b/src/jira/client.ts
@@ -1,3 +1,7 @@
+import type {
+  GetIssueCommentsParams,
+  JiraApiCommentsResponse,
+} from "./types/jira-comment.js";
 import type { JiraIssue } from "./types/jira-issue.js";
 import type { JiraApiResponse } from "./types/jira-response.js";
 
@@ -67,6 +71,52 @@ export class JiraClient {
 
     if (!response.ok) {
       throw new Error(`JIRA API error: ${response.statusText}`);
+    }
+
+    return response.json();
+  }
+
+  /**
+   * Get comments for a JIRA issue
+   */
+  async getIssueComments(
+    params: GetIssueCommentsParams
+  ): Promise<JiraApiCommentsResponse> {
+    const { issueIdOrKey, startAt, maxResults, orderBy, expand } = params;
+    const searchParams = new URLSearchParams();
+
+    if (startAt !== undefined) {
+      searchParams.append("startAt", startAt.toString());
+    }
+
+    if (maxResults !== undefined) {
+      searchParams.append("maxResults", maxResults.toString());
+    }
+
+    if (orderBy !== undefined) {
+      searchParams.append("orderBy", orderBy);
+    }
+
+    if (expand !== undefined) {
+      searchParams.append("expand", expand);
+    }
+
+    const response = await fetch(
+      `${
+        this.baseUrl
+      }/rest/api/3/issue/${issueIdOrKey}/comment?${searchParams.toString()}`,
+      {
+        headers: {
+          Authorization: `Basic ${this.auth}`,
+          Accept: "application/json",
+        },
+      }
+    );
+
+    if (!response.ok) {
+      throw new Error(
+        `JIRA API error (${response.status}): ${response.statusText}`
+      );
     }
 
     return response.json();

--- a/src/jira/formatters/comment-formatter.ts
+++ b/src/jira/formatters/comment-formatter.ts
@@ -1,0 +1,74 @@
+import type {
+  JiraApiComment,
+  JiraApiCommentsResponse,
+  JiraComment,
+  JiraCommentsResponse,
+} from "../types/jira-comment.js";
+import type { JiraMcpResponse } from "../types/jira-response.js";
+import { ADFConverter } from "../utils/adf-converter.js";
+
+/**
+ * Formats JIRA API comment responses into MCP response format
+ */
+export class CommentResponseFormatter {
+  /**
+   * Format a single JIRA comment
+   */
+  public static formatComment(comment: JiraApiComment): JiraComment {
+    return {
+      id: comment.id,
+      self: comment.self,
+      author: comment.author,
+      body: ADFConverter.convert(comment.body),
+      updateAuthor: comment.updateAuthor,
+      created: comment.created,
+      updated: comment.updated,
+      visibility: comment.visibility,
+    };
+  }
+
+  /**
+   * Format JIRA API comments response
+   */
+  public static formatResponse(
+    response: JiraApiCommentsResponse
+  ): JiraCommentsResponse {
+    return {
+      startAt: response.startAt,
+      maxResults: response.maxResults,
+      total: response.total,
+      comments: response.comments.map(this.formatComment),
+    };
+  }
+
+  /**
+   * Format JIRA comments for MCP response
+   */
+  public static format(response: JiraApiCommentsResponse): JiraMcpResponse {
+    const formattedResponse = this.formatResponse(response);
+
+    return {
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify(formattedResponse, null, 2),
+        },
+      ],
+    };
+  }
+
+  /**
+   * Format error response
+   */
+  public static formatError(error: Error): JiraMcpResponse {
+    return {
+      isError: true,
+      content: [
+        {
+          type: "text",
+          text: error.message,
+        },
+      ],
+    };
+  }
+}

--- a/src/jira/types/jira-comment.ts
+++ b/src/jira/types/jira-comment.ts
@@ -1,0 +1,74 @@
+/**
+ * JIRA Comment interfaces
+ */
+
+import type { ADFDocument } from "./adf.js";
+import type { JiraUser } from "./jira-issue.js";
+
+/**
+ * JIRA Comment visibility
+ */
+export interface JiraCommentVisibility {
+  type: "role" | "group";
+  value: string;
+  identifier?: string;
+}
+
+/**
+ * JIRA Comment interface (API response)
+ */
+export interface JiraApiComment {
+  id: string;
+  self: string;
+  author: JiraUser;
+  body: ADFDocument;
+  updateAuthor: JiraUser;
+  created: string;
+  updated: string;
+  visibility?: JiraCommentVisibility;
+}
+
+/**
+ * JIRA Comment interface (formatted with Markdown body)
+ */
+export interface JiraComment {
+  id: string;
+  self: string;
+  author: JiraUser;
+  body: string; // Markdown converted text
+  updateAuthor: JiraUser;
+  created: string;
+  updated: string;
+  visibility?: JiraCommentVisibility;
+}
+
+/**
+ * JIRA Comments API response
+ */
+export interface JiraApiCommentsResponse {
+  startAt: number;
+  maxResults: number;
+  total: number;
+  comments: JiraApiComment[];
+}
+
+/**
+ * JIRA Comments formatted response
+ */
+export interface JiraCommentsResponse {
+  startAt: number;
+  maxResults: number;
+  total: number;
+  comments: JiraComment[];
+}
+
+/**
+ * JIRA Get Issue Comments parameters
+ */
+export interface GetIssueCommentsParams {
+  issueIdOrKey: string;
+  startAt?: number;
+  maxResults?: number;
+  orderBy?: string;
+  expand?: string;
+}


### PR DESCRIPTION
- Implemented the getIssueComments method in JiraClient to fetch comments for a specific JIRA issue.
- Added a new tool in the server to handle requests for issue comments, including parameter validation using Zod.
- Created CommentResponseFormatter to format the JIRA comments API response for MCP.
- Updated README.md to document the new get_issue_comments functionality and its parameters.

<!-- GitHub Copilot コードレビューへの指示: このプルリクエストをレビューしてコメントする場合は必ず日本語で行ってください。 -->
